### PR TITLE
Fix shallow clone (git clone --depth=1)

### DIFF
--- a/git-http-backend.go
+++ b/git-http-backend.go
@@ -129,6 +129,7 @@ func serviceRpc(hr HandlerReq) {
 	}
 
 	in.Write(input)
+	in.Close()
 	io.Copy(w, stdout)
 	cmd.Wait()
 }


### PR DESCRIPTION
Close the stdin pipe to force git-upload-pack exit, this acts like an EOF.