### PR TITLE
Replace ioutil.ReadAll to io.Copy for copy request.body to stdin

### DIFF
--- a/git-http-backend.go
+++ b/git-http-backend.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
-	"compress/gzip"
 	"log"
 	"net/http"
 	"os"
@@ -105,8 +105,6 @@ func serviceRpc(hr HandlerReq) {
 		return
 	}
 
-	//input, _ := ioutil.ReadAll(r.Body)
-
 	w.Header().Set("Content-Type", fmt.Sprintf("application/x-git-%s-result", rpc))
 	w.WriteHeader(http.StatusOK)
 
@@ -128,7 +126,6 @@ func serviceRpc(hr HandlerReq) {
 		log.Print(err)
 	}
 
-	//in.Write(input)
 	var reader io.ReadCloser
 	switch r.Header.Get("Content-Encoding") {
 	case "gzip":
@@ -137,7 +134,7 @@ func serviceRpc(hr HandlerReq) {
 	default:
 		reader = r.Body
 	}
-	io.Copy(in,reader)
+	io.Copy(in, reader)
 	in.Close()
 	io.Copy(w, stdout)
 	cmd.Wait()


### PR DESCRIPTION
ioutil.ReadAll may cause too much memory consumption