### PR TITLE
small bug fixed

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -145,12 +145,13 @@ func serviceRpc(hr HandlerReq) {
 	args := []string{rpc, "--stateless-rpc", dir}
 	cmd := exec.Command(DefaultConfig.GitBinPath, args...)
 	version := r.Header.Get("Git-Protocol")
+	
+	cmd.Dir = dir
+	cmd.Env = env
 	if len(version) != 0 {
 		cmd.Env = append(env, fmt.Sprintf("GIT_PROTOCOL=%s", version))
 	}
-	cmd.Dir = dir
-	cmd.Env = env
-
+	
 	DefaultConfig.CommandFunc(cmd)
 
 	in, err := cmd.StdinPipe()


### PR DESCRIPTION
Hey, I think I have found a small bug and fixed it!
When client requests with header setting as "Git-Protocol: version=2", the origin code failed. The client shows error with "expected flush after ref listing". By using wireshark, I realized the server failed to handle the second request correctly.
![image](https://user-images.githubusercontent.com/75780183/203675030-022ca32b-9ad6-4374-b6d0-b67bab3b9b3f.png)
And finally I found that the cmd.Env is not set correctly when the "Git-Protocol" header is set since it's always going to be covered the second assignment. Simply changing the order of assignment works. 
It's my first time to create a pull request and try to make some contribution to your project. It will be kind of you to let me know if I did anything wrong.

